### PR TITLE
Print the real exception when DBH->connect fails

### DIFF
--- a/test/test.pl
+++ b/test/test.pl
@@ -158,7 +158,7 @@ my $strVersionSupport = versionSupport();
 
 if (!defined($strPgSqlBin))
 {
-    my @strySearchPath = ('/usr/lib/postgresql/VERSION/bin', '/usr/pgsql-VERSION/bin', '/Library/PostgreSQL/VERSION/bin');
+    my @strySearchPath = ('/usr/lib/postgresql/VERSION/bin', '/usr/pgsql-VERSION/bin', '/Library/PostgreSQL/VERSION/bin', '/usr/local/bin');
 
     foreach my $strSearchPath (@strySearchPath)
     {


### PR DESCRIPTION
Using eval { } as an error handler prevents the code from accessing
$DBI::errstr. Instead instruct DBI->connect to try without throwing
errors.

It would be better to exit immediately following a system error (module
not found, etc.), but this change reduces the time waiting for the
server to come up to 20 seconds.