### PR TITLE
semicolon supertiny fix

### DIFF
--- a/doc/doc.pl
+++ b/doc/doc.pl
@@ -115,7 +115,7 @@ if ($bQuiet)
 # If no keyword we passed then use default
 if (@stryKeyword == 0)
 {
-    @stryKeyword = ('default')
+    @stryKeyword = ('default');
 }
 
 logLevelSet(undef, uc($strLogLevel));


### PR DESCRIPTION
Though I realize the semicolon is optional, I'm adding it be consistent with the style in the document.